### PR TITLE
Fixed midrule at $8 of 'rule' has no declared type

### DIFF
--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -226,7 +226,7 @@ rule
 
         ERROR_IF(rule == NULL);
 
-        $$ = rule;
+        $<rule>$ = rule;
       }
       condition '}'
       {


### PR DESCRIPTION
Linux localhost 3.17.7-gentoo #1 SMP Wed Jan 7 09:38:05 CET 2015 i686 Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz GenuineIntel GNU/Linux
Bison version: bison (GNU Bison) 2.4.3

Error when compiling:

/bin/sh ../ylwrap grammar.y y.tab.c grammar.c y.tab.h `echo grammar.c | sed -e s/cc$/hh/ -e s/cpp$/hpp/ -e s/cxx$/hxx/ -e s/c++$/h++/ -e s/c$/h/` y.output grammar.output -- bison -y -d 
./yara/libyara/grammar.y:229.9-10: $$ for the midrule at $8 of `rule' has no declared type
